### PR TITLE
Added development mode when watch is used.

### DIFF
--- a/gulp-tasks/setenv.js
+++ b/gulp-tasks/setenv.js
@@ -1,0 +1,6 @@
+import gulp from 'gulp';
+
+gulp.task( 'set-prod-node-env', ( cb ) => {
+	process.env.NODE_ENV = 'production';
+	cb();
+} );

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -20,6 +20,7 @@ gulp.task( 'css', () => {
 } );
 
 gulp.task( 'watch', () => {
+	process.env.NODE_ENV = 'development';
 	livereload.listen( { basePath: 'dist' } );
 	gulp.watch( ['./assets/css/**/*.css', '!./assets/css/src/**/*.css'], ['css'] );
 	gulp.watch( './assets/js/**/*.js', ['js'] );
@@ -27,6 +28,7 @@ gulp.task( 'watch', () => {
 
 gulp.task( 'default', () => {
 	runSequence(
+		'set-prod-node-env',
 		'css',
 		'webpack'
 	);

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -40,7 +40,7 @@ const config = {
 			}
 		]
 	},
-	mode: 'production',
+	mode: process.env.NODE_ENV,
 	plugins: [
 		new webpack.NoEmitOnErrorsPlugin(),
 	],


### PR DESCRIPTION
@timwright12 I noticed what the default mode is set to production in webpack. The thing is when developing, it's good to have the mode set to development so that in certain cases, we get more verbose output, logs from libraries we are using. An good example is when I recently used Vue. If webpack is set to production mode, the Vue.js devtools Chrome extension does not appear. It only shows up in development mode. This PR sets the mode to development when using the watch task and then production mode when using the default build task. Let me know what you think :)