### PR TITLE
Add composer command to "deploy" to bring this inline with the plugin repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "npm install && gulp",
     "watch": "gulp watch",
     "build": "gulp",
-    "deploy": "npm install && gulp"
+    "deploy": "npm install && composer install --no-dev -o && gulp"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
The plugin repo has composer as part of the deploy command. PR adds that to keep them consistent.