### PR TITLE
Adding husky and lint-stage to ensure commits pass linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,21 @@
     "start": "npm install && gulp",
     "watch": "gulp watch",
     "build": "gulp",
-    "deploy": "npm install && composer install --no-dev -o && gulp"
+    "deploy": "npm install && composer install --no-dev -o && gulp",
+    "lint-js": "eslint assets/js",
+    "format-js": "eslint --fix assets/js",
+    "lint": "npm run lint-js",
+    "format": "npm run format-js"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint"
+    ]
   },
   "license": "MIT",
   "devDependencies": {
@@ -43,6 +57,8 @@
     "run-sequence": "^1.2.2",
     "webpack": "^4.0.1",
     "webpack-cli": "^2.0.10",
-    "webpack-stream": "^3.2.0"
+    "webpack-stream": "^3.2.0",
+    "husky": "^1.0.0-rc.7",
+    "lint-staged": "^7.1.2"
   }
 }


### PR DESCRIPTION
This PR ensures that all code is passing our lint process prior to commit. We can also run phpcs to ensure our PHP code is passing as well, but I haven added phpcs as we still need to work on our phpcs rules.

When commiting, if a JS code fails to pass the lint, commit will be aborted and issues will have to be fixed. This helps (and forces) engineers to stick to our standards and by doing this we can catch a lot of common issue/mistakes even before the code gets pushed.

If this looks good and is approved for merge I'll do the same for the plugin repo.