### PR TITLE
Updated gulp task to require Autoprefixer

### DIFF
--- a/gulp-tasks/css.js
+++ b/gulp-tasks/css.js
@@ -18,7 +18,8 @@ gulp.task( 'css', ( cb ) => {
 
 	const taskOpts = [
 		require( 'postcss-import' ),
-		require( 'postcss-preset-env' )( cssOpts )
+		require( 'postcss-preset-env' )( cssOpts ),
+		require( 'autoprefixer' )
 	];
 
 	pump( [

--- a/gulp-tasks/css.js
+++ b/gulp-tasks/css.js
@@ -13,13 +13,15 @@ gulp.task( 'css', ( cb ) => {
 	const fileDest = './dist';
 
 	const cssOpts = {
-		stage: 0
+		stage: 0,
+		autoprefixer: {
+			grid: true
+		}
 	};
 
 	const taskOpts = [
 		require( 'postcss-import' ),
 		require( 'postcss-preset-env' )( cssOpts ),
-		require( 'autoprefixer' )
 	];
 
 	pump( [


### PR DESCRIPTION
Fixes a problem where Autoprefixer is not run during the Gulp build task. 
This issue was originally discovered after inspecting `.min.css` files in the `dist` folder.