### PR TITLE
Skip processing Bower Components/Node Modules

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -22,6 +22,7 @@ const config = {
 		rules: [
 			{
 				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
 				enforce: 'pre',
 				loader: 'eslint-loader',
 				options: {
@@ -30,6 +31,7 @@ const config = {
 			},
 			{
 				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
 				use: [{
 					loader: 'babel-loader',
 					options: {


### PR DESCRIPTION
I feel that node_modules/bower_components should be skipped by default.