### PR TITLE
Add async/defer tags for enqueueing scripts

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -21,6 +21,8 @@ function setup() {
 	add_action( 'after_setup_theme', $n( 'theme_setup' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
+
+	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
 }
 
 /**
@@ -97,4 +99,38 @@ function styles() {
 			TENUP_SCAFFOLD_VERSION
 		);
 	}
+}
+
+/**
+ * Add async/defer attributes to enqueued scripts that have the specified script_execution flag.
+ *
+ * @link https://core.trac.wordpress.org/ticket/12009
+ * @param string $tag    The script tag.
+ * @param string $handle The script handle.
+ * @return string
+ */
+function script_loader_tag( $tag, $handle ) {
+	$script_execution = wp_scripts()->get_data( $handle, 'script_execution' );
+
+	if ( ! $script_execution ) {
+		return $tag;
+	}
+
+	if ( 'async' !== $script_execution && 'defer' !== $script_execution ) {
+		return $tag; // _doing_it_wrong()?
+	}
+
+	// Abort adding async/defer for scripts that have this script as a dependency. _doing_it_wrong()?
+	foreach ( wp_scripts()->registered as $script ) {
+		if ( in_array( $handle, $script->deps, true ) ) {
+			return $tag;
+		}
+	}
+
+	// Add the attribute if it hasn't already been added.
+	if ( ! preg_match( ":\s$script_execution(=|>|\s):", $tag ) ) {
+		$tag = preg_replace( ':(?=></script>):', " $script_execution", $tag, 1 );
+	}
+
+	return $tag;
 }


### PR DESCRIPTION
Fixes #51 

I'm not sure how we want to handle documentation/recommendations for usage?

Example, in order to use you would put something like this in current Theme Scaffold's `includes/core.php`:

__Currently:__
```
function scripts() {

	wp_enqueue_script(
		'frontend',
		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/frontend.min.js',
		[],
		TENUP_SCAFFOLD_VERSION,
		true
	);

}
```

__Recommended Usage:__
```
function scripts() {

	wp_enqueue_script(
		'frontend',
		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/frontend.min.js',
		[],
		TENUP_SCAFFOLD_VERSION,
		true
	);

	// Should you prefer to load frontend.min.js async
	wp_script_add_data(
		'frontend', 
		'script_execution', 
		'async' 
	);

}
```