### PR TITLE
Allow snake_case and camelCase in object keys.

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -12,7 +12,7 @@ const config = {
 	},
 	output: {
 		path: DIST_PATH,
-		filename: '[name].min.js',
+		filename: data => `${ data.chunk.name.replace( /\.?([A-Z])/g, letter => '-' + letter.toLowerCase() ).replace( '_', '-' ) }.min.js`,
 	},
 	resolve: {
 		modules: ['node_modules'],


### PR DESCRIPTION
The object keys of the entry property does allow for usage of `snake_case` and `camelCase` keys. This causes an issue with files names not following the hyphenated standard.

This pull request fixes that issue.