### PR TITLE
Feature/gutenberg theme support

### DIFF
--- a/assets/css/frontend/base/blocks.css
+++ b/assets/css/frontend/base/blocks.css
@@ -1,0 +1,45 @@
+/* Set aspect ratios on embeds in Gutenberg blocks */
+.wp-has-aspect-ratio .wp-block-embed__wrapper {
+	height: 0;
+	overflow: hidden;
+	padding-top: 56.25%;
+	position: relative;
+
+	& iframe {
+		height: 100%;
+		left: 0;
+		max-width: 100%;
+		position: absolute;
+		top: 0;
+		width: 100%;
+	}
+}
+
+.wp-embed-aspect-21-9 .wp-block-embed__wrapper {
+	padding-top: 42.85%;
+}
+
+.wp-embed-aspect-18-9 .wp-block-embed__wrapper,
+.wp-embed-aspect-9-16 .wp-block-embed__wrapper {
+	padding-top: 50%;
+}
+
+.wp-embed-aspect-16-9 .wp-block-embed__wrapper {
+	padding-top: 56.25%;
+}
+
+.wp-embed-aspect-4-3 .wp-block-embed__wrapper {
+	padding-top: 75%;
+}
+
+.wp-embed-aspect-1-1 .wp-block-embed__wrapper {
+	padding-top: 100%;
+}
+
+.wp-embed-aspect-9-6 .wp-block-embed__wrapper {
+	padding-top: 66.66%;
+}
+
+.wp-embed-aspect-1-2 .wp-block-embed__wrapper {
+	padding-top: 200%;
+}

--- a/assets/css/frontend/base/index.css
+++ b/assets/css/frontend/base/index.css
@@ -1,2 +1,3 @@
+@import url("blocks.css");
 @import url("prefers-reduced-motion.css");
 @import url("wordpress.css");

--- a/includes/core.php
+++ b/includes/core.php
@@ -45,6 +45,10 @@ function theme_setup() {
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'title-tag' );
 	add_theme_support( 'post-thumbnails' );
+	add_theme_support( 'disable-custom-font-sizes' );
+	add_theme_support( 'disable-custom-colors' );
+	add_theme_support( 'editor-color-palette', array() );
+
 	add_theme_support(
 		'html5',
 		array(


### PR DESCRIPTION
**Rationale**: 

Unless we enable responsive-embeds support, we should add our own styles for styling embeds responsively. I've added a new blocks.css file for this. My thought is that if we add more block-specific styles, we can then start splitting this out into more specific partials (perhaps embeds.css in this case). 

`add_theme_support( 'disable-custom-font-sizes' );`
— Disables the custom font size input box.

`add_theme_support( 'disable-custom-colors' );`
— disables the core colour palette 

`add_theme_support( 'editor-color-palette', array() );`
— if we disable the core colour palette, we need to pass in our own array of (0) colours.


As Damon and I discussed in Slack, further work needs to be broken out into separate issues so we can properly have discussion around them. this is meant to be a few obvious defaults.