### PR TITLE
Move Search Component from Library into Scaffolding

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -141,7 +141,7 @@ function script_loader_tag( $tag, $handle ) {
 	}
 
 	if ( 'async' !== $script_execution && 'defer' !== $script_execution ) {
-		return $tag; // _doing_it_wrong()?
+		return $tag;
 	}
 
 	// Abort adding async/defer for scripts that have this script as a dependency. _doing_it_wrong()?

--- a/search.php
+++ b/search.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The template for displaying search results pages.
+ *
+ * @package TenUpScaffold
+ */
+
+get_header(); ?>
+
+	<section itemscope itemtype="https://schema.org/SearchResultsPage">
+		<?php if ( have_posts() ) : ?>
+			<h1>
+				<?php printf( esc_html__( 'Search Results for: %s', 'tenup' ), '<span>' . esc_html( get_search_query() ) . '</span>' ); ?>
+			</h1>
+
+			<ul>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
+
+				<li>
+					<h2><?php the_title(); ?></h2>
+					<?php the_excerpt(); ?>
+				</li>
+
+			<?php endwhile; ?>
+			</ul>
+		<?php endif; ?>
+	</section>
+
+<?php
+get_footer();

--- a/search.php
+++ b/search.php
@@ -19,13 +19,23 @@ get_header(); ?>
 				the_post();
 				?>
 
-				<li>
-					<h2><?php the_title(); ?></h2>
-					<?php the_excerpt(); ?>
+				<li itemscope itemtype="https://schema.org/Thing">
+					<?php
+					if ( has_post_thumbnail() ) {
+						the_post_thumbnail();
+					}
+
+					the_title( '<span itemprop="name"><a href="' . esc_url( get_permalink() ) . '" itemprop="url">', '</a></span>' );
+					?>
+					<div itemprop="description">
+						<?php the_excerpt(); ?>
+					</div>
 				</li>
 
 			<?php endwhile; ?>
 			</ul>
+
+			<?php the_posts_navigation(); ?>
 		<?php endif; ?>
 	</section>
 

--- a/search.php
+++ b/search.php
@@ -10,7 +10,10 @@ get_header(); ?>
 	<section itemscope itemtype="https://schema.org/SearchResultsPage">
 		<?php if ( have_posts() ) : ?>
 			<h1>
-				<?php printf( esc_html__( 'Search Results for: %s', 'tenup' ), '<span>' . esc_html( get_search_query() ) . '</span>' ); ?>
+				<?php
+				/* translators: the search query */
+				printf( esc_html__( 'Search Results for: %s', 'tenup' ), '<span>' . esc_html( get_search_query() ) . '</span>' );
+				?>
 			</h1>
 
 			<ul>

--- a/searchform.php
+++ b/searchform.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The template for displaying the search form.
+ *
+ * @package TenUpScaffold
+ */
+
+?>
+
+<form role="search" class="search-form" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	<label for="search-field">
+		<?php echo esc_html_x( 'Search for:', 'label', 'tenup' ); ?>
+	</label>
+	<input type="search" id="search-field" value="<?php echo get_search_query(); ?>" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'tenup' ); ?>" name="s" />
+	<input type="submit" value="<?php echo esc_attr_x( 'Submit', 'submit button', 'tenup' ); ?>">
+</form>

--- a/searchform.php
+++ b/searchform.php
@@ -7,10 +7,13 @@
 
 ?>
 
-<form role="search" class="search-form" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-	<label for="search-field">
-		<?php echo esc_html_x( 'Search for:', 'label', 'tenup' ); ?>
-	</label>
-	<input type="search" id="search-field" value="<?php echo get_search_query(); ?>" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'tenup' ); ?>" name="s" />
-	<input type="submit" value="<?php echo esc_attr_x( 'Submit', 'submit button', 'tenup' ); ?>">
-</form>
+<div itemscope itemtype="http://schema.org/WebSite">
+	<form role="search" id="searchform" class="search-form" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+		<meta itemprop="target" content="<?php echo esc_url( home_url() ); ?>/?s={s}" />
+		<label for="search-field">
+			<?php echo esc_html_x( 'Search for:', 'label', 'tenup' ); ?>
+		</label>
+		<input itemprop="query-input" type="search" id="search-field" value="<?php echo get_search_query(); ?>" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'tenup' ); ?>" name="s" />
+		<input type="submit" value="<?php echo esc_attr_x( 'Submit', 'submit button', 'tenup' ); ?>">
+	</form>
+</div>


### PR DESCRIPTION
Addresses #117 

I pulled in most markup from existing 10up Component library. I did _not_ pull in the Schema markup. I have not seen Schema usage in scaffold elsewhere, therefore thought it unnecessary.

* 10up Component Library - [Search action](https://10up.github.io/wp-component-library/component/search-action/index.html)
* 10up Component Library - [Search results](https://10up.github.io/wp-component-library/component/search-results/index.html)