### PR TITLE
Re-add template-tags.php scaffolded file

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,6 +12,7 @@ define( 'TENUP_SCAFFOLD_PATH', get_template_directory() . '/' );
 define( 'TENUP_SCAFFOLD_INC', TENUP_SCAFFOLD_PATH . 'includes/' );
 
 require_once TENUP_SCAFFOLD_INC . 'core.php';
+require_once TENUP_SCAFFOLD_INC . 'template-tags.php';
 require_once TENUP_SCAFFOLD_INC . 'utility.php';
 
 // Run the setup functions.

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Custom template tags for this theme.
+ *
+ * This file is for custom template tags only and it should not contain
+ * functions that will be used for filtering or adding an action.
+ *
+ * All functions should be prefixed with TenUpScaffold in order to prevent
+ * pollution of the global namespace and potential conflicts with functions
+ * from plugins.
+ * Example: `tenup_function()`
+ *
+ * @package ThemeScaffold\Template_Tags
+ */


### PR DESCRIPTION
In #129, we moved the functions in `template-tags.php` to `utility.php` since that made more sense.  This left no functions (empty with the exception of comments) in `template-tags.php` so it was deleted.  If we want to keep the file for scaffolding purposes, this PR adds it back.

cc: @colorful-tones @timwright12 