### PR TITLE
Correct a11y test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In most cases `webpack.settings.js` is the main file which would change from pro
 - `npm run lint` (run all lints)
 - `npm run format-js` (format JS using eslint)
 - `npm run format` (alias for `npm run format-js`)
-- `npm run test-a11y` (run accessibility tests)
+- `npm run test:a11y` (run accessibility tests)
 
 ## Composer Commands
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The readme had the test a11y command as `test-a11y` when the package.json had the command listed as `test:a11y`. This fixes the readme file.

### Benefits

Correct documentation.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
