### PR TITLE
Fix Gutenberg Scaffold

### DIFF
--- a/config/webpack.settings.js
+++ b/config/webpack.settings.js
@@ -5,9 +5,11 @@ module.exports = {
 	entries: {
 		// JS files.
 		'admin': './assets/js/admin/admin.js',
+		'blocks': './assets/js/blocks/blocks.js',
 		'frontend': './assets/js/frontend/frontend.js',
 		'shared': './assets/js/shared/shared.js',
 		'styleguide': './assets/js/styleguide/styleguide.js',
+		'blocks-editor': './includes/blocks/blocks-editor.js',
 
 		// CSS files.
 		'admin-style': './assets/css/admin/admin-style.css',

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -32,7 +32,7 @@ function blocks_scripts() {
 
 	wp_enqueue_script(
 		'blocks',
-		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks.min.js',
+		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks.js',
 		[],
 		TENUP_SCAFFOLD_VERSION,
 		true
@@ -49,7 +49,7 @@ function blocks_editor_scripts() {
 
 	wp_enqueue_script(
 		'blocks-editor',
-		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks-editor.min.js',
+		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks-editor.js',
 		[ 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components' ],
 		TENUP_SCAFFOLD_VERSION,
 		false

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
     "@wordpress/babel-preset-default": "^4.1.0",
+    "@wordpress/element": "^2.5.0",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.0",
     "backstopjs": "^3.2",


### PR DESCRIPTION
### Description of the Change

I think something was lost in translation when we introduced the webpack-only scaffold. The blocks-related JS are not compiling anymore (missing from settings).

### Benefits

Newer projects using the scaffold won't have the 404 on the blocks JS anymore.

### Verification Process

Compiled locally, this is also a change I had to do on 2 recent builds

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
