### PR TITLE
Prefix editor-style.css with .editor-styles-wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lint-staged": "^8.1.3",
     "mini-css-extract-plugin": "^0.5.0",
     "pa11y": "^5.0.4",
+    "postcss-editor-styles": "^0.1.5",
     "postcss-import": "^12.0.0",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^5.3.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -12,6 +12,30 @@ module.exports = ( { file, options, env } ) => ( { /* eslint-disable-line */
 				grid: true
 			}
 		},
+		// Prefix editor styles with class `editor-styles-wrapper`.
+		'postcss-editor-styles': 'editor-style.css' === file.basename ?
+			{
+				scopeTo: '.editor-styles-wrapper',
+				ignore: [
+					':root',
+					'.edit-post-visual-editor.editor-styles-wrapper',
+					'.wp-toolbar',
+				],
+				remove: [
+					'html',
+					':disabled',
+					'[readonly]',
+					'[disabled]',
+				],
+				tags: [
+					'button',
+					'input',
+					'label',
+					'select',
+					'textarea',
+					'form',
+				],
+			} : false,
 		// Minify style on production using cssano.
 		cssnano: 'production' === env ?
 			{


### PR DESCRIPTION
### Description of the Change

Kudos to @samikeijonen for this! I think it's nice to have that in the scaffold.
This allows the styles to be shared between frontend and Gutenberg, without overriding the default WP admin styles.

### Alternate Designs

Another way to do this is to use `add_editor_style()` rather than the action `enqueue_block_editor_assets`, but the right way of including Gutenberg styling is with the latter.

### Benefits

Being able to use the same CSS partials for frontend and Gutenberg, without having to go through crazy prefixing.
Having a close experience between Gutenberg and frontend.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Tried this on a production project
Tried building locally on the scaffold with dummy styles

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
