### PR TITLE
Feature/reorganize globals

### DIFF
--- a/assets/css/frontend/global/colors.css
+++ b/assets/css/frontend/global/colors.css
@@ -1,0 +1,7 @@
+/*
+ * Colors
+ */
+:root {
+	--c-black: #000;
+	--c-white: #fff;
+}

--- a/assets/css/frontend/global/index.css
+++ b/assets/css/frontend/global/index.css
@@ -1,1 +1,2 @@
-@import url("variables");
+@import url("colors.css");
+@import url("media-queries.css");

--- a/assets/css/frontend/global/media-queries.css
+++ b/assets/css/frontend/global/media-queries.css
@@ -4,7 +4,13 @@
 :root {
 
 	@custom-media --bp-tiny ( min-width: 25em ); /* 400px */
-	@custom-media --bp-small ( min-width: 40.625em ); /* 650px */
-	@custom-media --bp-medium ( min-width: 53.125em ); /* 850px */
-	@custom-media --bp-large ( min-width: 62.5em ); /* 1000px */
+	@custom-media --bp-small ( min-width: 30em ); /* 480px */
+	@custom-media --bp-medium ( min-width: 48em ); /* 768px */
+	@custom-media --bp-large ( min-width: 64em ); /* 1024px */
+	@custom-media --bp-xlarge ( min-width: 80em ); /* 1280px */
+	@custom-media --bp-xxlarge ( min-width: 90em ); /* 1440px */
+
+	/* WP Core Breakpoints (used for the admin bar for example) */
+	@custom-media --wp-small ( min-width: 600px );
+	@custom-media --wp-medium-max (max-width: 782px);
 }

--- a/assets/css/frontend/global/media-queries.css
+++ b/assets/css/frontend/global/media-queries.css
@@ -1,12 +1,10 @@
+/*
+ * Media Queries
+ */
 :root {
 
-	--c-black: #000;
-	--c-white: #fff;
-	
-	/* Breakpoints */
 	@custom-media --bp-tiny ( min-width: 25em ); /* 400px */
 	@custom-media --bp-small ( min-width: 40.625em ); /* 650px */
 	@custom-media --bp-medium ( min-width: 53.125em ); /* 850px */
 	@custom-media --bp-large ( min-width: 62.5em ); /* 1000px */
-
 }

--- a/templates/page-styleguide.php
+++ b/templates/page-styleguide.php
@@ -24,7 +24,7 @@ get_header();
 	<div class="uikit__content">
 
 		<?php
-			$colors = get_colors( '/assets/css/frontend/global/variables.css' );
+			$colors = get_colors( '/assets/css/frontend/global/colors.css' );
 
 		if ( ! empty( $colors ) ) :
 			?>


### PR DESCRIPTION
### Description of the Change

Looks like the preference on recent projects has been to break down the variables into several files, which I think make more sense and keep things tidier.
I've removed the `variables.css` file and created `colors.css` and `media-queries.css`
I've also updated `media-queries.css` to use breakpoints I've seen more frequently across projects and added WP breakpoints used by the admin bar.

### Benefits

Tidier variables on large projects

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Compiled locally

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
