### PR TITLE
Remove .min from file names.

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -32,7 +32,7 @@ function blocks_scripts() {
 
 	wp_enqueue_script(
 		'blocks',
-		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks.min.js',
+		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks.js',
 		[],
 		TENUP_SCAFFOLD_VERSION,
 		true
@@ -49,7 +49,7 @@ function blocks_editor_scripts() {
 
 	wp_enqueue_script(
 		'blocks-editor',
-		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks-editor.min.js',
+		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/js/blocks-editor.js',
 		[ 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components' ],
 		TENUP_SCAFFOLD_VERSION,
 		false
@@ -57,7 +57,7 @@ function blocks_editor_scripts() {
 
 	wp_enqueue_style(
 		'editor-style',
-		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/css/editor-style.min.css',
+		TENUP_SCAFFOLD_TEMPLATE_URL . '/dist/css/editor-style.css',
 		[],
 		TENUP_SCAFFOLD_VERSION
 	);


### PR DESCRIPTION
Fixes #167.

Remove `.min` from file names.

## Benefits

We don't generate `.min` files, so makes sense to use correct file names.

Note that `blocks.js` and `blocks-editor.js` doesn't have entry point by default in `config/webpack.settings.js`. But that's separate issue if they want to be added.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
