### PR TITLE
Do not clean dist folder on watch if not needed.

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -112,7 +112,9 @@ module.exports = {
 		} ),
 
 		// Clean the `dist` folder on build.
-		new CleanWebpackPlugin(),
+		new CleanWebpackPlugin( {
+			cleanStaleWebpackAssets: false,
+		} ),
 
 		// Extract CSS into individual files.
 		new MiniCssExtractPlugin( {


### PR DESCRIPTION
Fixes #165.

### Description of the Change

Don't automatically remove all unused webpack assets on rebuild.

### Benefits

Unused folder should not be removed when using `npm run watch`.

### Verification Process

1. Run `npm run watch`.
1. Update any CSS to re-build.
1. Note that `dist/icons` folder is not removed anymore.
1. Same would apply to `dist/fonts` etc. folders.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
