### PR TITLE
Add lodash as global to prevent this.activateMode is not a function error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "react/jsx-uses-vars": "error"
   },
   "globals": {
-    "wp": true,
+		"wp": true,
+		"lodash": true
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "react/jsx-uses-vars": "error"
   },
   "globals": {
-		"wp": true,
-		"lodash": true
+    "wp": true,
+    "lodash": true
   }
 }

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -40,6 +40,7 @@ module.exports = {
 	// External objects.
 	externals: {
 		jquery: 'jQuery',
+		lodash: 'lodash',
 	},
 
 	// Performance settings.


### PR DESCRIPTION
Fixes #166.

### Description of the Change

Fix `this.activateMode is not a function error` by adding `lodash` as global.

### Benefits
Remove the error which is there by default in theme-scaffold and crashing the editor.

### Possible Drawbacks

None that I can think of.

### Verification Process

1. Use example block inside theme scaffold.
1. Run `npm run watch`.
1. Add featured image to post. 
1. Editor crashes with the error message described in the this issue.
1. Adding `lodash` as global fixes the issue, and editor works again. 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
