### PR TITLE
Fix: Composer Autoloader / WP CLI compatibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -22,8 +22,8 @@ TenUpScaffold\Core\setup();
 TenUpScaffold\Blocks\setup();
 
 // Require Composer autoloader if it exists.
-if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-	require_once 'vendor/autoload.php';
+if ( file_exists( TENUP_SCAFFOLD_PATH . 'vendor/autoload.php' ) ) {
+	require_once TENUP_SCAFFOLD_PATH . 'vendor/autoload.php';
 }
 
 if ( ! function_exists( 'wp_body_open' ) ) {


### PR DESCRIPTION
### Description of the Change

Recently I ran in to an issue where the Composer autoloader was not engaging when executing WP CLI commands.

With the theme activated;

```
Uncaught Error: Class '[namespace\class]' not found in ...
```

Following the information about people with similar issues on the WP CLI repo - specifically this comment; https://github.com/wp-cli/wp-cli/issues/4632#issuecomment-432023390 - the fix was to change the `require` line for the `autoload.php` file.

Previously this was using a relative path. The fix was change it to use an absolute path instead, utilising the `TENUP_SCAFFOLD_PATH` constant to form an absolute path for `require_once`.

This change mimics the code used on the Plugins Scaffold here;

https://github.com/10up/plugin-scaffold/blob/132c7cc6fc7cf534953d5cca73b44a68096e2db6/plugin.php#L31-L34

### Verification Process

_**Please note; below is a test scenario I used for this change. However, it did not reproduce the issue I experience on my project. I described both below for evaluation.**_

In the project I am working on there is three autoloaders within the codebase;

* For supporting general libraries within `wp-config.php` used in conjunction with AWS.
* A Must-Use plugin created with Plugin Scaffold.
* Theme created with the Theme Scaffold.

There is must be a nuance of these three autoloaders being together that is causing the problem with WP CLI that I have been unable to pinpoint accurately enough to replicate. However, the fix in this PR does resolve the issue on that project.

It also does not impact the Theme Scaffold for the following steps, which are included for completeness.

1. Added `theme-scaffold` to the `wp-content/themes/` folder on a vanilla WP install.
2. Run `composer install`
3. Created a basic custom class in the `theme-scaffold/includes/classes/` folder.
4. Activate the theme.
5. Create a test plugin using the plugin scaffold, `create-10up plugin my-test-plugin`.
6. Activate plugin.
7. Run WP CLI command such as `wp options list`.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Fixed: incompatibilities with Composer autoloader and WP CLI under certain conditions.