### PR TITLE
Replace 'tenup' with 'tenup-placeholder'

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 /**
  * Babel Config, .babelrc equivalent.
  *
- * @package TenUpThemeScaffold
+ * @package TenUpScaffold
  *
  * @type {{presets: [[]|String|Object]}}
  */

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -81,8 +81,8 @@ function blocks_categories( $categories, $post ) {
 		$categories,
 		array(
 			array(
-				'slug'  => 'tenup-blocks',
-				'title' => __( 'Custom Blocks', 'tenup' ),
+				'slug'  => 'tenup-scaffold-blocks',
+				'title' => __( 'Custom Blocks', 'tenup-scaffold' ),
 			),
 		)
 	);

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -2,7 +2,7 @@
 /**
  * Gutenberg Blocks setup
  *
- * @package ThemeScaffold\Core
+ * @package TenUpScaffold\Core
  */
 
 namespace TenUpScaffold\Blocks;

--- a/includes/blocks/example-block-1/index.js
+++ b/includes/blocks/example-block-1/index.js
@@ -13,12 +13,12 @@ const { TextControl } = wp.components;
 export default registerBlockType(
 	'tenup/example-block',
 	{
-		title: __( 'My first block', 'tenup' ),
-		description: __( 'My first block description', 'tenup' ),
+		title: __( 'My first block', 'tenup-scaffold' ),
+		description: __( 'My first block description', 'tenup-scaffold' ),
 		icon: 'smiley',
-		category: 'tenup-blocks',
+		category: 'tenup-scaffold-blocks',
 		keywords: [
-			__( 'example', 'tenup' ),
+			__( 'example', 'tenup-scaffold' ),
 		],
 		attributes: {
 			customTitle: {
@@ -43,7 +43,7 @@ export default registerBlockType(
 					<div className={ className }>
 						<TextControl
 							id="example-block-text-field"
-							label={ __( 'Custom Title', 'tenup' ) }
+							label={ __( 'Custom Title', 'tenup-scaffold' ) }
 							value={ customTitle }
 							onChange={ customTitle => setAttributes( { customTitle } ) }
 						/>

--- a/includes/core.php
+++ b/includes/core.php
@@ -58,7 +58,7 @@ function theme_setup() {
 	// This theme uses wp_nav_menu() in three locations.
 	register_nav_menus(
 		array(
-			'primary' => esc_html__( 'Primary Menu', 'tenup' ),
+			'primary' => esc_html__( 'Primary Menu', 'tenup-scaffold' ),
 		)
 	);
 }

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -10,7 +10,7 @@
  * from plugins.
  * Example: `tenup_function()`
  *
- * @package ThemeScaffold\Template_Tags
+ * @package TenUpScaffold\Template_Tags
  *
  */
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -8,7 +8,7 @@
  * All functions should be prefixed with TenUpScaffold in order to prevent
  * pollution of the global namespace and potential conflicts with functions
  * from plugins.
- * Example: `tenup_function()`
+ * Example: `tenup_scaffold_function()`
  *
  * @package TenUpScaffold\Template_Tags
  *

--- a/search.php
+++ b/search.php
@@ -12,7 +12,7 @@ get_header(); ?>
 			<h1>
 				<?php
 				/* translators: the search query */
-				printf( esc_html__( 'Search Results for: %s', 'tenup' ), '<span>' . esc_html( get_search_query() ) . '</span>' );
+				printf( esc_html__( 'Search Results for: %s', 'tenup-scaffold' ), '<span>' . esc_html( get_search_query() ) . '</span>' );
 				?>
 			</h1>
 

--- a/searchform.php
+++ b/searchform.php
@@ -11,9 +11,9 @@
 	<form role="search" id="searchform" class="search-form" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 		<meta itemprop="target" content="<?php echo esc_url( home_url() ); ?>/?s={s}" />
 		<label for="search-field">
-			<?php echo esc_html_x( 'Search for:', 'label', 'tenup' ); ?>
+			<?php echo esc_html_x( 'Search for:', 'label', 'tenup-scaffold' ); ?>
 		</label>
-		<input itemprop="query-input" type="search" id="search-field" value="<?php echo get_search_query(); ?>" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'tenup' ); ?>" name="s" />
-		<input type="submit" value="<?php echo esc_attr_x( 'Submit', 'submit button', 'tenup' ); ?>">
+		<input itemprop="query-input" type="search" id="search-field" value="<?php echo get_search_query(); ?>" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'tenup-scaffold' ); ?>" name="s" />
+		<input type="submit" value="<?php echo esc_attr_x( 'Submit', 'submit button', 'tenup-scaffold' ); ?>">
 	</form>
 </div>


### PR DESCRIPTION
### Description of the Change

- Updates namespace strings from `tenup` to `tenup-scaffold`
- Updates package name placeholders from `ThemeScaffold` and `TenUpThemeScaffold`
to `TenUpScaffold`
- Adds `tenup-scaffold` string to example block category slug

### Benefits

The [10up Project Scaffold](https://github.com/10up/project-scaffold) command line tool replaces `tenup-scaffold` and `TenUpScaffold` with the human-theme-name variable, and this project's readme file tells you to do the same manually. The incorrect strings would not get replaced correctly.

### Changelog Entry

Fix placeholder strings
