### PR TITLE
Added core functions to allow for asynchrnous CSS loading

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -26,7 +26,11 @@ function setup() {
 	add_action( 'wp_head', $n( 'js_disabled_stylesheets' ) );
 
 	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
-	add_filter( 'style_loader_tag', $n( 'style_loader_tag' ), 10, 2 );
+
+	if ( ! is_admin() ) {
+		add_filter( 'style_loader_tag', $n( 'style_loader_tag' ), 10, 2 );
+	}
+
 }
 
 /**
@@ -167,12 +171,12 @@ function script_loader_tag( $tag, $handle ) {
  *
  * Determines which stylesheets should behave
  * asynchronously on the page by storing their
- * unique handles in an array.
+ * unique handle in an array.
  *
  * @return array
  */
 function get_known_handles() {
-	return array( 'styles', 'styleguide', 'wp-block-library' );
+	return array( 'admin-bar', 'dashicons', 'styles', 'styleguide', 'wp-block-library' );
 }
 
 /**
@@ -191,41 +195,15 @@ function style_loader_tag( $html, $handle ) {
 	// Loop over stylesheets and replace media attribute
 	foreach ( $known_handles as $known_style ) {
 		if ( $known_style === $handle ) {
-			$html = str_replace( "media='all'", "media='print' onload=\"this.media='all'\"", $html );
+			$print_html = str_replace( "media='all'", "media='print' onload=\"this.media='all'\"", $html );
 		}
+	}
+
+	if ( ! empty( $print_html ) ) {
+		$html = $print_html . '<noscript>' . $html . '</noscript>';
 	}
 
 	return $html;
-}
-
-/**
- * Asynchronous CSS Fallback
- *
- * If JavaScript is disabled, this function ensures
- * that the CSS for the page still loads as expected.
- *
- * @link https://developer.wordpress.org/reference/functions/wp_styles/
- * @return void
- */
-function js_disabled_stylesheets() {
-
-	// Grab our known stylesheet handles
-	$known_handles = get_known_handles();
-
-	$html = '<noscript id="async-css-fallback">';
-
-	// Loop over all enqueued stylesheets on the page.
-	foreach ( wp_styles()->queue as $style ) {
-
-		// If we the current queue contains our known stylesheet handles append them.
-		if ( in_array( $style, $known_handles, true ) ) {
-			$html .= "<link rel='stylesheet' href='" . esc_url( wp_styles()->registered[ $style ]->src ) . "' media='all' />" . PHP_EOL; // phpcs:ignore
-		}
-	}
-
-	$html .= '</noscript>';
-
-	echo $html; // phpcs:ignore
 }
 
 /**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Adds 3 new functions to `core.php` for handling asynchronous CSS mentioned in: https://github.com/10up/theme-scaffold/issues/199

The 3 functions are:
- `get_known_handles`
- `style_loader_tag`

These functions handle 3 pieces of functionality respectively:
1. Returns a collection of stylesheets we want to behave asynchronously
2. Hooks into the `style_loader_tag` action and filters the HTML that is returned by default by WordPress Core
3. When JS is disabled - the stylesheets are called normally, albeit in a manual way.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Benefits
- Selected stylesheets will now load asynchronously as the `media="print"` attribute is loaded before the DOM is complete and styles are applied. The `onload` attribute then applies the styles by updating `media="print"` to `media="all"`.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

- The way the current implementation works is rather manually - my PHP has become a bit rusty over the years so I would appreciate further insight into how to get these functions to behave more dynamically.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- Stylesheets still load and apply styles when JS is disabled
- Tracked the waterfall movement of stylesheets being called in the Network tab in Chrome
- Inline JS works as styles are applied `onload`

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
